### PR TITLE
Fix empty watchlist bug

### DIFF
--- a/Movies/Movies/ViewControllers/SavedMoviesListViewController.swift
+++ b/Movies/Movies/ViewControllers/SavedMoviesListViewController.swift
@@ -51,16 +51,13 @@ extension SavedMoviesListViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        switch viewModel.viewState {
-        case .initial, .nonempty:
-            do {
-                try viewModel.fetchItems()
+        do {
+            try viewModel.fetchItems()
+            if viewModel.viewState == .nonempty {
                 collectionView.reloadData()
-            } catch {
-                print(error)
             }
-        default:
-            break
+        } catch {
+            print(error)
         }
     }
 }
@@ -124,7 +121,6 @@ extension SavedMoviesListViewController: UICollectionViewDataSource {
 }
 
 enum SavedMovieViewControllerState: ViewControllerState {
-    case initial
     case empty
     case nonempty
 }
@@ -135,7 +131,7 @@ extension SavedMoviesListViewController: StateTogglingViewController {
         case .empty:
             collectionView.isHidden = true
             emptyStateView.isHidden = false
-        case .nonempty, .initial:
+        case .nonempty:
             collectionView.isHidden = false
             emptyStateView.isHidden = true
         }

--- a/Movies/Movies/ViewModels/SavedMoviesListViewModel.swift
+++ b/Movies/Movies/ViewModels/SavedMoviesListViewModel.swift
@@ -11,7 +11,7 @@ class SavedMoviesListViewModel {
     let coreDataStore: CoreDataStore
     let imageLoader: ImageLoader
 
-    var viewState: SavedMovieViewControllerState = .initial {
+    var viewState: SavedMovieViewControllerState = .empty {
         didSet {
             delegate?.toggleState(viewState)
         }


### PR DESCRIPTION
On viewWillDidAppear of SavedMoviesListVC, fetch saved items before checking view state to determine if the collection should be reloaded (prevent unnecessary reload call if the collection is hidden during empty state)