### PR TITLE
Improve watchlist loading

### DIFF
--- a/Movies/Movies/ViewControllers/SavedMoviesListViewController.swift
+++ b/Movies/Movies/ViewControllers/SavedMoviesListViewController.swift
@@ -50,13 +50,15 @@ extension SavedMoviesListViewController {
         view = stack
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         do {
             try viewModel.fetchMovies()
             if viewModel.viewState == .nonempty {
                 Task {
                     await MainActor.run {
-                        collectionView.reloadData()
+                        collectionView.performBatchUpdates {
+                            collectionView.reloadSections(.init(integer: 0))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Reload list in performBatchUpdates to support animation
- Use viewDidAppear to see the list update in real-time
- ViewDidAppear also helps avoid a bug where sometimes the list didn't show the complete data (replicable by adding 2 movies via the now-playing tab, then removing these movies via the watchlist tab, then adding 2 more movies on the now-playing tab - the watchlist will show the last movie added on the first viewWillAppear, and then show all 2 movies after triggering a second viewWillAppear)
- Help from https://developer.apple.com/forums/thread/93054?answerId=281593022#281593022